### PR TITLE
Fix video player height and do not show it for non-video shares

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -105,6 +105,6 @@
 #imgframe .video-js:not(.vjs-fullscreen),
 #imgframe .video-js:not(.vjs-fullscreen) .vjs-tech {
 	max-height: calc(100vh - 280px) !important;
-	min-height: 100px;
+	min-width: 300px;
 	max-width: 100% !important;
 }

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -122,17 +122,22 @@ $(document).ready(function(){
 		}
 	});
 
+	var isSupportedMimetype = false;
+	var mimetype = $('#mimetype').val();
+
 	if (typeof FileActions !== 'undefined') {
 		for (var i = 0; i < videoViewer.mimeTypes.length; ++i) {
 			var mime = videoViewer.mimeTypes[i];
 			OCA.Files.fileActions.register(mime, 'View', OC.PERMISSION_READ, '', videoViewer.onView);
 			OCA.Files.fileActions.setDefault(mime, 'View');
+			if (mime === mimetype) {
+				isSupportedMimetype = true;
+			}
 		}
 	}
 
-	if($('#body-public').length && $('#imgframe').length) {
+	if($('#body-public').length && $('#imgframe').length && isSupportedMimetype) {
 		var videoUrl = $('#downloadURL').val();
-		var mimetype = $('#mimetype').val();
 		videoViewer.onViewInline($('#imgframe'), videoUrl, mimetype);
 	}
 


### PR DESCRIPTION
Follow-up PR of #52 

- Increase default video player width
- Do not show player on non-video shares like when sharing a text file