### PR TITLE
Do not get the url from the download links

### DIFF
--- a/js/viewer.js
+++ b/js/viewer.js
@@ -147,7 +147,7 @@ $(document).ready(function(){
 	}
 
 	if($('#body-public').length && $('#imgframe').length && isSupportedMimetype) {
-		var videoUrl = $('#downloadURL').val();
+		var videoUrl = window.location + '/download';
 		videoViewer.onViewInline($('#imgframe'), videoUrl, mimetype);
 	}
 


### PR DESCRIPTION
If the download is hidden this url does not exist. We should just generate it ourselfs.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>