### PR TITLE
Fill screen in fullscreen mode for public videos. Fixes #77

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -102,6 +102,12 @@
 	height: auto;
 }
 
+/* fullscreen public videos see https://github.com/nextcloud/files_videoplayer/issues/77 */
+#imgframe .video-js.vjs-fullscreen .vjs-tech {
+	width:100%;
+	height:100%;
+}
+
 #imgframe .video-js:not(.vjs-fullscreen),
 #imgframe .video-js:not(.vjs-fullscreen) .vjs-tech {
 	max-height: calc(100vh - 280px) !important;


### PR DESCRIPTION
Tested on: Chrome 71, Firefox 57, Safari 12